### PR TITLE
Consider adding optional first-party shuttle support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,10 @@ repository = "https://github.com/Kay-Conte/vegemite-rs/"
 categories = ["web-programming::http-server", "web-programming"]
 rust-version = "1.65.0"
 
+[features]
+shuttle = ["dep:shuttle-service", "dep:async-trait"]
+
 [dependencies]
 http = "0.2.9"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+shuttle-service = { version = "0.27.0", optional = true }
+async-trait = { version = "0.1.73", optional = true }

--- a/examples/shuttle.rs
+++ b/examples/shuttle.rs
@@ -1,0 +1,21 @@
+//!
+//! A simple vegemite application ready to deploy to https://shuttle.rs/.
+//!
+//! Use the `shuttle` feature along with `shuttle-runtime` and `tokio` for the following example.
+//!
+//! To run locally, use `cargo shuttle run` after running `cargo install cargo-shuttle`.
+//!
+//! To deploy to shuttle, create an environment using `cargo shuttle project start` and deploy using `cargo shuttle deploy`.
+//!
+
+use vegemite::{Get, Response};
+
+fn hello(_get: Get) -> Response<String> {
+    Response::new(String::from("Hello, World!"))
+}
+
+#[shuttle_runtime::main]
+async fn main() -> Result<Route, shuttle_runtime::Error> {
+    let router = Route::new(sys![hello]);
+    Ok(router)
+}

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -39,3 +39,12 @@ impl Route {
         self.children.get(path)
     }
 }
+
+#[cfg(feature = "shuttle")]
+#[async_trait::async_trait]
+impl shuttle_service::Service for Route {
+    async fn bind(self, addr: std::net::SocketAddr) -> Result<(), shuttle_service::Error> {
+        crate::run(addr, self);
+        Ok(())
+    }
+}


### PR DESCRIPTION
because that grants the user the luxury of not having to call `router.into()` at the minimal cost of 8 lines of library code
also why not